### PR TITLE
Add a regfile testbench

### DIFF
--- a/testbenches/regfile-rw.mlir
+++ b/testbenches/regfile-rw.mlir
@@ -1,0 +1,82 @@
+!addr_t = i5
+!rw_independent_t = !arc.sim.instance<@rw_independent>
+
+func.func private @tick.rw_independent(%model : !rw_independent_t) {
+  %hi = hw.constant 1 : i1
+  %lo = hw.constant 0 : i1
+
+  arc.sim.set_input %model, "clk" = %hi : i1, !rw_independent_t
+  arc.sim.step %model : !rw_independent_t
+
+  arc.sim.set_input %model, "clk" = %lo : i1, !rw_independent_t
+  arc.sim.step %model : !rw_independent_t
+
+  return
+}
+
+hw.module @rw_independent(in %clk : i1, in %rst : i1, out rd : i32) {
+  %clk.clk = seq.to_clock %clk
+
+  %lo = hw.constant 0 : i1
+  %hi = hw.constant 1 : i1
+
+  %r0 = hw.constant 0 : !addr_t
+  %r1 = hw.constant 1 : !addr_t
+  %r2 = hw.constant 2 : !addr_t
+
+  %i1 = hw.constant 1 : i32
+
+  %state.1 = hw.constant 1 : i2
+
+  %state.init = hw.constant 0 : i2
+  %state.write = hw.constant 1 : i2
+  %state.read = hw.constant 2 : i2
+
+  %rd1, %rd2 = hw.instance "regfile" @regfile(clk: %clk: i1, we: %we: i1, wa: %r1: !addr_t, wd: %wd: i32, ra1: %r1: !addr_t, ra2: %r2: !addr_t) -> (rd1: i32, rd2: i32)
+
+  // %state.init -> %state.write (-> %state.read)*
+  %state = seq.compreg %state.next, %clk.clk reset %rst, %state.init : i2
+  %state.inc = comb.add %state, %state.1 : i2
+  %state.next = comb.mux %is_state_read, %state.read, %state.inc : i2
+
+  %is_state_init = comb.icmp eq %state, %state.init : i2
+  %is_state_write = comb.icmp eq %state, %state.write : i2
+  %is_state_read = comb.icmp eq %state, %state.read : i2
+
+  %we = comb.or %is_state_init, %is_state_write : i1
+
+  %wd.init = hw.constant 42 : i32
+  %wd.write = comb.add %rd2, %i1 : i32
+  %wd = comb.mux %is_state_init, %wd.init, %wd.write : i32
+
+  hw.output %rd1 : i32
+}
+
+func.func @entry() {
+  %lo = hw.constant 0 : i1
+  %hi = hw.constant 1 : i1
+
+  // read-write (independent registers) ///////////////////////////////////////
+  arc.sim.instantiate @rw_independent as %model {
+    // reset
+    arc.sim.set_input %model, "rst" = %hi : i1, !rw_independent_t
+    func.call @tick.rw_independent(%model) : (!rw_independent_t) -> ()
+
+    // init
+    arc.sim.set_input %model, "rst" = %lo : i1, !rw_independent_t
+    func.call @tick.rw_independent(%model) : (!rw_independent_t) -> ()
+
+    // write
+    func.call @tick.rw_independent(%model) : (!rw_independent_t) -> ()
+
+    // read
+    func.call @tick.rw_independent(%model) : (!rw_independent_t) -> ()
+
+    %rd = arc.sim.get_port %model, "rd" : i32, !rw_independent_t
+
+    // CHECK: rd = 2b
+    arc.sim.emit "rd", %rd : i32
+  }
+
+  return
+}

--- a/testbenches/regfile.mlir
+++ b/testbenches/regfile.mlir
@@ -1,0 +1,126 @@
+!regfile_t = !arc.sim.instance<@regfile>
+!addr_t = i5
+
+!tick_t = (!regfile_t) -> ()
+!set_inputs_t = (!regfile_t, i1, !addr_t, i32, !addr_t, !addr_t) -> ()
+!emit_outputs_t = (!regfile_t) -> ()
+!run_read_t = (!regfile_t, !addr_t, !addr_t) -> ()
+!run_write_t = (!regfile_t, !addr_t, i32) -> ()
+
+func.func private @tick(%model : !regfile_t) {
+  %hi = hw.constant 1 : i1
+  %lo = hw.constant 0 : i1
+
+  arc.sim.set_input %model, "clk" = %hi : i1, !regfile_t
+  arc.sim.step %model : !regfile_t
+
+  arc.sim.set_input %model, "clk" = %lo : i1, !regfile_t
+  arc.sim.step %model : !regfile_t
+
+  return
+}
+
+func.func private @set_inputs(%model : !regfile_t, %we : i1, %wa : !addr_t, %wd : i32, %ra1 : !addr_t, %ra2 : !addr_t) {
+  arc.sim.set_input %model, "we" = %we : i1, !regfile_t
+  arc.sim.set_input %model, "wa" = %wa : !addr_t, !regfile_t
+  arc.sim.set_input %model, "wd" = %wd : i32, !regfile_t
+  arc.sim.set_input %model, "ra1" = %ra1 : !addr_t, !regfile_t
+  arc.sim.set_input %model, "ra2" = %ra2 : !addr_t, !regfile_t
+
+  return
+}
+
+func.func private @emit_outputs(%model : !regfile_t) {
+  %rd1 = arc.sim.get_port %model, "rd1" : i32, !regfile_t
+  %rd2 = arc.sim.get_port %model, "rd2" : i32, !regfile_t
+
+  arc.sim.emit "rd1", %rd1 : i32
+  arc.sim.emit "rd2", %rd2 : i32
+
+  return
+}
+
+func.func private @run_read(%model : !regfile_t, %ra1 : !addr_t, %ra2 : !addr_t) {
+  %lo = hw.constant 0 : i1
+  %r0 = hw.constant 0 : !addr_t
+  %i0 = hw.constant 0 : i32
+
+  func.call @set_inputs(%model, %lo, %r0, %i0, %ra1, %ra2) : !set_inputs_t
+  func.call @tick(%model) : !tick_t
+  func.call @emit_outputs(%model) : !emit_outputs_t
+
+  return
+}
+
+func.func private @run_write(%model : !regfile_t, %wa : !addr_t, %wd : i32) {
+  %hi = hw.constant 1 : i1
+  %r0 = hw.constant 0 : !addr_t
+  func.call @set_inputs(%model, %hi, %wa, %wd, %r0, %r0) : !set_inputs_t
+  func.call @tick(%model) : !tick_t
+
+  return
+}
+
+func.func @entry() {
+  %lo = hw.constant 0 : i1
+  %hi = hw.constant 1 : i1
+
+  %r0 = hw.constant 0 : !addr_t
+  %r1 = hw.constant 1 : !addr_t
+  %r2 = hw.constant 2 : !addr_t
+  %r3 = hw.constant 3 : !addr_t
+  %r4 = hw.constant 4 : !addr_t
+
+  %i0 = hw.constant 0 : i32
+  %i24 = hw.constant 24 : i32
+  %i42 = hw.constant 42 : i32
+  // 0b11110011000011001001011010010110
+  %i0xf30c9696 = hw.constant 0xf30c9696 : i32
+
+  // zero register read ///////////////////////////////////////////////////////
+  arc.sim.instantiate @regfile as %model {
+    // CHECK: rd1 = 0
+    func.call @run_read(%model, %r0, %r1) : !run_read_t
+
+    // CHECK: rd2 = 0
+    func.call @run_read(%model, %r1, %r0) : !run_read_t
+
+    // CHECK: rd1 = 0
+    // CHECK: rd2 = 0
+    func.call @run_read(%model, %r0, %r0) : !run_read_t
+  }
+
+  // register write ///////////////////////////////////////////////////////////
+  arc.sim.instantiate @regfile as %model {
+    func.call @run_write(%model, %r1, %i42) : !run_write_t
+    func.call @tick(%model) : !tick_t
+
+    // CHECK: rd1 = 2a
+    func.call @run_read(%model, %r1, %r0) : !run_read_t
+
+    // ensure that the register is only overwritten on a clock tick
+    func.call @set_inputs(%model, %hi, %r1, %i0xf30c9696, %r1, %r0) : !set_inputs_t
+    arc.sim.step %model : !regfile_t
+    // CHECK: rd1 = 2a
+    func.call @emit_outputs(%model) : !emit_outputs_t
+    func.call @tick(%model) : !tick_t
+    // CHECK: rd1 = f30c9696
+    func.call @emit_outputs(%model) : !emit_outputs_t
+  }
+
+  // dual-port read ///////////////////////////////////////////////////////////
+  arc.sim.instantiate @regfile as %model {
+    func.call @run_write(%model, %r1, %i24) : !run_write_t
+    func.call @run_write(%model, %r2, %i42) : !run_write_t
+
+    // CHECK: rd1 = 18
+    // CHECK: rd2 = 2a
+    func.call @run_read(%model, %r1, %r2) : !run_read_t
+
+    // CHECK: rd1 = 18
+    // CHECK: rd2 = 18
+    func.call @run_read(%model, %r1, %r1) : !run_read_t
+  }
+
+  return
+}


### PR DESCRIPTION
See YAGRIT/flow#42. Almost all cases are covered, save the read-write loop case (wherein `wd` depends on `rd1`/`rd2`), which I just can't seem to figure out yet (Arcilator doesn't like, well, the combinatorial loop that's required for the test scenario).